### PR TITLE
Only support node v4+, use native Promises

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,3 @@ language: node_js
 node_js:
   - "6"
   - "4"
-  - "0.12"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
   "main": "dist/client.js",
   "dependencies": {
     "@rahatarmanahmed/event-kit": "^2.1.0-featureonce",
-    "bluebird": "^3.3.1",
     "debug": "^2.2.0",
     "irc-colors": "^1.2.0",
     "irc-message": "~3.0.0",
@@ -18,6 +17,7 @@
     "through2-map": "^2.0.0"
   },
   "devDependencies": {
+    "bluebird": "^3.4.6",
     "chai": "^3.5.0",
     "coffee-script": "^1.10.0",
     "coffeelint": "^1.14.2",

--- a/src/plugins/core/join.coffee
+++ b/src/plugins/core/join.coffee
@@ -1,5 +1,4 @@
 {getSender} = require '../../util'
-Promise = require 'bluebird'
 
 module.exports = ->
 	return (client) ->

--- a/src/plugins/core/nick.coffee
+++ b/src/plugins/core/nick.coffee
@@ -1,6 +1,5 @@
 {getSender} = require '../../util'
 {getReplyCode} = require '../../replies'
-Promise = require 'bluebird'
 
 module.exports = ->
 	return (client) ->

--- a/src/plugins/core/part.coffee
+++ b/src/plugins/core/part.coffee
@@ -1,5 +1,4 @@
 {getSender} = require '../../util'
-Promise = require 'bluebird'
 
 module.exports = ->
 	return (client) ->

--- a/src/plugins/core/topic.coffee
+++ b/src/plugins/core/topic.coffee
@@ -1,5 +1,3 @@
-Promise = require 'bluebird'
-{promiseForEvent} = require '../../util'
 {getReplyCode} = require '../../replies'
 
 module.exports = ->

--- a/test/ClientTest.coffee
+++ b/test/ClientTest.coffee
@@ -65,21 +65,6 @@ describe 'Client', ->
 			client.disconnect 'Choke on it.'
 			return server.expect 'QUIT :Choke on it.'
 
-		it 'should run the callback on successful disconnect', ->
-			client._.disconnecting.should.be.false
-
-			disconnectPromise = new Promise (resolve) ->
-				client.disconnect ->
-					client._.disconnecting.should.be.false
-					client.isConnected().should.be.false
-					client.isConnecting().should.be.false
-					resolve()
-			quitPromise = server.expect 'QUIT'
-			.then ->
-				client._.disconnecting.should.be.true
-				server.reply 'ERROR :Closing Link: cpe-76-183-227-155.tx.res.rr.com (Client Quit)'
-			return Promise.all([disconnectPromise, quitPromise])
-
 		it 'should resolve the promise on successful disconnect', ->
 			client._.disconnecting.should.be.false
 			disconnectPromise = client.disconnect()


### PR DESCRIPTION
We get to remove bluebird, but now we don't suppot callbacks for connect and disconnect methods.

Resolves #24 