### PR TITLE
Add id to client events for general use

### DIFF
--- a/src/client.coffee
+++ b/src/client.coffee
@@ -12,6 +12,8 @@ debugError = require('debug')('squelch-client:error')
 {getSender} = require './util'
 {getReplyCode, getReplyName} = require './replies'
 
+nextId = 1
+
 defaultOpt =
 	port: 6667
 	nick: 'NodeIRCClient'
@@ -37,6 +39,7 @@ defaultOpt =
 class Client extends Emitter
 	constructor: (opt) ->
 		super()
+		@id = nextId++
 		@_ =
 			internalEmitter: new Emitter()
 			numRetries: 0
@@ -84,6 +87,7 @@ class Client extends Emitter
 	# external listeners.
 	# NOTE: internalEmitter won't receive error events
 	emit: (args...) ->
+		args[1].id = @id if typeof args[1] is 'object'
 		@_.internalEmitter.emit args... if args[0] isnt 'error'
 		super args...
 

--- a/test/ClientTest.coffee
+++ b/test/ClientTest.coffee
@@ -55,6 +55,17 @@ describe 'Client', ->
 			client.opt.username.should.equal 'NodeIRCTestBot'
 			client.opt.realname.should.equal 'I do the tests.'
 			client.opt.autoConnect.should.equal false
+		it 'should set an incremental id on the client', ->
+			client = new Client('./test/testConfig.json')
+			client2 = new Client('./test/testConfig.json')
+			client.id.should.be.greaterThan 0
+			client2.id.should.equal client.id + 1
+
+	describe 'events', ->
+		it 'should provide id on event data objects', ->
+			client._.internalEmitter.on 'test-event', ({id}) -> id.should.equal client.id
+			client.on 'test-event', ({id}) -> id.should.equal client.id
+			client.emit 'test-event', {some: 'data'}
 
 	describe 'disconnect', ->
 		it 'should send QUIT to the server and null the connection', ->


### PR DESCRIPTION
Useful if you have to manage multiple clients.